### PR TITLE
Improving clustering

### DIFF
--- a/tests/testEmpty.py
+++ b/tests/testEmpty.py
@@ -4,8 +4,8 @@ import numpy as np
 from emptySpace.emptyspace import Empty_Space
 from numpy import genfromtxt
 
-random_gaussian = np.random.normal(size=(102,10))
-es = Empty_Space(random_gaussian, 30, 2)
+random_gaussian = np.random.normal(size=(30,4))
+es = Empty_Space(random_gaussian, 10, 2)
 es.find_empty_space()
 data, ghost = es.scale()
 es.plot()


### PR DESCRIPTION
This PR changes the way centerpoints are clustered so that you can throw away counterpoints below a certain distance threshold. This is useful because it allows for k-means to more accurately identify where the empty space cluster centers should be. Further experimenting will have to occur to find the optimum threshold.